### PR TITLE
Fix responsive navigation menu

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -811,16 +811,16 @@ input:focus, select:focus, textarea:focus {
     bottom: -8px;
 }
 
-.nav-open .hamburger {
+.main-nav.nav-open .hamburger {
     background: transparent;
 }
 
-.nav-open .hamburger::before {
+.main-nav.nav-open .hamburger::before {
     transform: rotate(45deg);
     top: 0;
 }
 
-.nav-open .hamburger::after {
+.main-nav.nav-open .hamburger::after {
     transform: rotate(-45deg);
     top: 0;
 }
@@ -861,9 +861,10 @@ input:focus, select:focus, textarea:focus {
         box-shadow: var(--shadow-lg);
         border-radius: var(--radius-lg);
         animation: fadeInDown 0.3s ease-out;
+        z-index: 1000;
     }
 
-    .nav-links.nav-open {
+    .main-nav.nav-open .nav-links {
         display: flex;
     }
 

--- a/js/app.js
+++ b/js/app.js
@@ -185,11 +185,18 @@ const App = {
     setupEventListeners() {
         // ... (event listeners remain mostly the same)
         // Navigation
+        const mainNav = document.querySelector('.main-nav');
         document.querySelectorAll('.nav-links a').forEach(link => {
             link.addEventListener('click', (e) => {
                 e.preventDefault();
                 const page = link.getAttribute('data-page');
-                if (page) UI.showPage(page);
+                if (page) {
+                    UI.showPage(page);
+                    // Close the mobile nav on link click
+                    if (mainNav.classList.contains('nav-open')) {
+                        mainNav.classList.remove('nav-open');
+                    }
+                }
             });
         });
 
@@ -259,9 +266,8 @@ const App = {
         const navToggle = document.querySelector('.nav-toggle');
         if (navToggle) {
             navToggle.addEventListener('click', () => {
-                const navLinks = document.querySelector('.nav-links');
-                navLinks.classList.toggle('nav-open');
-                navToggle.classList.toggle('nav-open');
+                const mainNav = document.querySelector('.main-nav');
+                mainNav.classList.toggle('nav-open');
             });
         }
     },


### PR DESCRIPTION
This commit fixes the responsive navigation menu by refactoring the CSS and JavaScript that control its behavior.

- The CSS has been updated to use a single `.nav-open` class on the `.main-nav` element to control the open state of the navigation menu.
- The `z-index` of the navigation links has been increased to ensure they appear above other content.
- The JavaScript has been updated to toggle the `.nav-open` class on the `.main-nav` element when the hamburger icon is clicked.
- The navigation menu now closes automatically when a navigation link is clicked.