### PR TITLE
Fix: Add robust validation for adding a person

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -307,8 +307,14 @@ const App = {
         const name = nameInput.value.trim();
         const emoji = emojiInput.value;
 
-        if (name === '') { /* validation */ return; }
-        if (this.data.people.some(p => p.name.toLowerCase() === name.toLowerCase())) { /* validation */ return; }
+        if (name === '') {
+            Swal.fire('Oops!', 'Person name cannot be empty.', 'error');
+            return;
+        }
+        if (this.data.people.some(p => p.name.toLowerCase() === name.toLowerCase())) {
+            Swal.fire('Oops!', `A person named "${name}" already exists.`, 'error');
+            return;
+        }
 
         const newPersonData = { name, emoji };
 
@@ -320,7 +326,17 @@ const App = {
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(newPersonData),
                 });
-                if (!response.ok) throw new Error('Server error');
+                if (!response.ok) {
+                    let errorMessage = 'An unknown server error occurred.';
+                    try {
+                        const errorData = await response.json();
+                        errorMessage = errorData.error || `Server responded with status ${response.status}.`;
+                    } catch (e) {
+                        // Response was not JSON or was empty
+                        errorMessage = `Server responded with status ${response.status}.`;
+                    }
+                    throw new Error(errorMessage);
+                }
                 savedPerson = await response.json();
                 savedPerson.id = parseInt(savedPerson.id);
                 savedPerson.totalPaid = 0;
@@ -338,7 +354,7 @@ const App = {
             Swal.fire('Person Added!', `${name} has been added.`, 'success');
         } catch (error) {
             console.error('Error adding person:', error);
-            Swal.fire('Error!', 'Could not add person.', 'error');
+            Swal.fire('Error!', `Could not add person. ${error.message}`, 'error');
         }
     },
 

--- a/php/api.php
+++ b/php/api.php
@@ -137,6 +137,18 @@ function get_all_data($conn, $userId) {
 }
 
 function add_person($conn, $data, $userId) {
+    // Input validation
+    if (!isset($data['name']) || trim($data['name']) === '') {
+        http_response_code(400); // Bad Request
+        echo json_encode(['error' => 'Person name is required.']);
+        return;
+    }
+    if (!isset($data['emoji']) || trim($data['emoji']) === '') {
+        http_response_code(400); // Bad Request
+        echo json_encode(['error' => 'Emoji is required.']);
+        return;
+    }
+
     $name = $conn->real_escape_string($data['name']);
     $emoji = $conn->real_escape_string($data['emoji']);
 


### PR DESCRIPTION
This commit fixes the "couldn't add person" error by implementing comprehensive validation on both the frontend and backend.

- **Frontend (js/app.js):**
  - Added client-side validation to prevent submitting empty or duplicate person names.
  - Implemented user-friendly error alerts using SweetAlert2 for immediate feedback.
  - Enhanced the `addPerson` function to parse and display specific error messages returned from the server.

- **Backend (php/api.php):**
  - Added server-side validation to the `add_person` function to ensure `name` and `emoji` are present and not empty.
  - The API now returns a 400 Bad Request status with a clear error message if validation fails.

This ensures a more robust and user-friendly experience for both online and offline modes.